### PR TITLE
Adding the output redirection symbol

### DIFF
--- a/ConsoleRunner.php
+++ b/ConsoleRunner.php
@@ -64,7 +64,7 @@ class ConsoleRunner extends Component
         if ($this->isWindows() === true) {
             pclose(popen('start /b ' . $cmd, 'r'));
         } else {
-            pclose(popen($cmd . ' /dev/null &', 'r'));
+            pclose(popen($cmd . ' > /dev/null &', 'r'));
         }
         return true;
     }


### PR DESCRIPTION
Hi Vasile.

At the moment the output data are not sent to the `/dev/null` file. Besides that, without the output redirection symbol the `/dev/null` part is processed like the action parameter, and if the default value in the action is `null`, it is ignored.