### PR TITLE
Improve: Linux background command - In order to execute a command in …

### DIFF
--- a/ConsoleRunner.php
+++ b/ConsoleRunner.php
@@ -64,7 +64,7 @@ class ConsoleRunner extends Component
         if ($this->isWindows() === true) {
             pclose(popen('start /b ' . $cmd, 'r'));
         } else {
-            pclose(popen($cmd . ' > /dev/null &', 'r'));
+            pclose(popen($cmd . ' > /dev/null 2>&1 &', 'r'));
         }
         return true;
     }


### PR DESCRIPTION
…a background, the program you run must not output back to php. To do this, redirect both stdout and stderr to /dev/null, then background it.