### PR TITLE
Некорректная работа при использовании php-fpm

### DIFF
--- a/ConsoleRunner.php
+++ b/ConsoleRunner.php
@@ -41,6 +41,11 @@ class ConsoleRunner extends Component
     public $file;
 
     /**
+     * @var string $phpBinaryPath Path to php binary (optional)
+     */
+    public $phpBinaryPath;
+
+    /**
      * @inheritdoc
      */
     public function init()
@@ -50,6 +55,7 @@ class ConsoleRunner extends Component
         if ($this->file === null) {
             throw new InvalidConfigException('The "file" property must be set.');
         }
+        $this->phpBinaryPath = $this->phpBinaryPath ?: $this->getDefaultPhpBinaryPath();
     }
 
     /**
@@ -60,12 +66,12 @@ class ConsoleRunner extends Component
      */
     public function run($cmd)
     {
-        $cmd = PHP_BINARY . ' ' . Yii::getAlias($this->file) . ' ' . $cmd;
-        if ($this->isWindows() === true) {
-            pclose(popen('start /b ' . $cmd, 'r'));
-        } else {
-            pclose(popen($cmd . ' > /dev/null 2>&1 &', 'r'));
-        }
+        $executableFilePath = \Yii::getAlias($this->file);
+        $command = "{$this->phpBinaryPath} $executableFilePath $cmd";
+        $systemDependentCommand = ($this->isWindows()) ? "start /b $command" : "$command > /dev/null 2>&1 &";
+
+        pclose(popen($systemDependentCommand, "r"));
+
         return true;
     }
 
@@ -81,5 +87,15 @@ class ConsoleRunner extends Component
         } else {
             return false;
         }
+    }
+
+    /**
+     * Default path to php binary
+     *
+     * @return string
+     */
+    private function getDefaultPhpBinaryPath()
+    {
+        return PHP_BINARY;
     }
 }

--- a/ConsoleRunner.php
+++ b/ConsoleRunner.php
@@ -23,7 +23,8 @@ use yii\base\InvalidConfigException;
  * components [
  *     'consoleRunner' => [
  *         'class' => 'vova07\console\ConsoleRunner',
- *         'file' => '@my/path/to/yii' // or an absolute path to console file
+ *         'file' => '@my/path/to/yii', // or an absolute path to console file
+ *         'phpBinaryPath' => '/usr/bin/php'
  *     ]
  * ]
  * ...


### PR DESCRIPTION
При использовании расширения в окружении с php-fpm возникает проблема - константа PHP_BINARY указывает на php-fpm, а не на php-cli.
Кто-то уже писал о такой проблеме - https://github.com/vova07/yii2-console-runner-extension/issues/10. 
Чтобы не возвращаться к старому варианту можно позволить задавать путь к бинарнику php в настройках компонента.
